### PR TITLE
Resolution to GB Authentication issue

### DIFF
--- a/lghorizon/const.py
+++ b/lghorizon/const.py
@@ -119,9 +119,7 @@ COUNTRY_SETTINGS = {
     },
     "gb": {
         "api_url": "https://spark-prod-gb.gnp.cloud.virgintvgo.virginmedia.com",
-        "oauth_url": "https://id.virginmedia.com/rest/v40/session/start?protocol=oidc&rememberMe=true",
         "channels": [],
-        "oesp_url": "https://prod.oesp.virginmedia.com/oesp/v4/GB/eng/web",
         "language": "en",
     },
     "ie": {

--- a/lghorizon/lghorizon_api.py
+++ b/lghorizon/lghorizon_api.py
@@ -1,4 +1,5 @@
 """Python client for LGHorizon."""
+
 import logging
 import json
 import sys, traceback

--- a/test.py
+++ b/test.py
@@ -52,11 +52,17 @@ if __name__ == "__main__":
     try:
         secrets_file_path = "secrets.json"
         secrets = read_secrets(secrets_file_path)
+
+        refresh_token = None
+        if "refresh_token" in secrets:
+            refresh_token = secrets["refresh_token"]
+
         api = LGHorizonApi(
             secrets["username"],
             secrets["password"],
             secrets["country"],
             # identifier="DTV3907048",
+            refresh_token = refresh_token,
         )
         api.connect()
         event_loop()


### PR DESCRIPTION
The library element of a PR to resolve the issue that the GB integration was no longer working...

https://github.com/Sholofly/lghorizon/issues/82

Changes:
- replaced `authorise_gb` with new code.   
- reverted GB MQTT token to default - GB specific code generated errors.

The authorise_gb code uses a supplied refresh_token, rather than username/password to login.
Not as convenient for the user, but avoids the challenge of emulating the GB OAUTH process.