### PR TITLE
Fix: Use refresh token auth when refresh_token is provided

### DIFF
--- a/lghorizon/lghorizon_models.py
+++ b/lghorizon/lghorizon_models.py
@@ -504,7 +504,7 @@ class LGHorizonAuth:
         self._token_expiry = None
         self._country_code = country_code
         self._host = COUNTRY_SETTINGS[country_code]["api_url"]
-        self._use_refresh_token = COUNTRY_SETTINGS[country_code]["use_refreshtoken"]
+        self._use_refresh_token = COUNTRY_SETTINGS[country_code]["use_refreshtoken"] or bool(refresh_token)
         self._service_config = None
         self._token_refresh_callback = token_refresh_callback
 


### PR DESCRIPTION
## Problem

When a `refresh_token` is explicitly passed to `LGHorizonAuth()`, the library ignores it for countries where `use_refreshtoken=False` (e.g., Ziggo/Netherlands).

This causes authentication failures when:
1. Initial setup authenticates with username/password
2. A refresh token is returned and stored
3. On reconnection, the stored refresh token is passed
4. But because `use_refreshtoken=False`, the library tries password auth
5. The refresh token is incorrectly used as a password → "Encryption failed"

## Solution

If a `refresh_token` is explicitly provided, use refresh token auth regardless of country settings:

```python
self._use_refresh_token = COUNTRY_SETTINGS[country_code]["use_refreshtoken"] or bool(refresh_token)
```

The `use_refreshtoken` country setting should only determine the **initial** authentication method. If a refresh token is available from a previous successful auth, it should always be used.

## Affected Providers

This benefits all providers where `use_refreshtoken=False`:
- nl (Ziggo)
- ie (Virgin Media Ireland)
- pl (UPC Poland)

## Backward Compatibility

Fully backward compatible:
- No `refresh_token` provided → behavior unchanged
- `refresh_token` provided → now correctly uses refresh token auth