### PR TITLE
Normalize all epoch timestamps from milliseconds to seconds

### DIFF
--- a/lghorizon/lghorizon_device_state_processor.py
+++ b/lghorizon/lghorizon_device_state_processor.py
@@ -203,7 +203,7 @@ class LGHorizonDeviceStateProcessor:
         device_state.episode_number = replay_event.episode_number
         device_state.show_title = replay_event.title
         device_state.last_position_update = int(
-            player_state.last_speed_change_time / 1000
+            player_state.last_speed_change_time
         )
         device_state.position = int(player_state.relative_position / 1000)
         device_state.start_time = replay_event.start_time
@@ -250,7 +250,7 @@ class LGHorizonDeviceStateProcessor:
         device_state.episode_number = replay_event.episode_number
         device_state.show_title = replay_event.title
         device_state.last_position_update = int(
-            player_state.last_speed_change_time / 1000
+            player_state.last_speed_change_time
         )
         device_state.start_time = replay_event.start_time
         device_state.end_time = replay_event.end_time
@@ -321,7 +321,7 @@ class LGHorizonDeviceStateProcessor:
         device_state.season_number = recording.season_number
         device_state.episode_number = recording.episode_number
         device_state.last_position_update = int(
-            player_state.last_speed_change_time / 1000
+            player_state.last_speed_change_time
         )
         device_state.position = int(player_state.relative_position / 1000)
         if recording.start_time:

--- a/lghorizon/lghorizon_models.py
+++ b/lghorizon/lghorizon_models.py
@@ -306,9 +306,10 @@ class LGHorizonPlayerState:
     @property
     def last_speed_change_time(
         self,
-    ) -> int:
+    ) -> Optional[float]:
         """Return the last speed change time."""
-        return self._raw_json.get("lastSpeedChangeTime", 0.0)
+        val = self._raw_json.get("lastSpeedChangeTime")
+        return val / 1000 if val is not None else None
 
     @property
     def relative_position(
@@ -427,9 +428,10 @@ class LGHorizonUIStatusMessage(LGHorizonMessage):
         return self._payload.get("source", "unknown")
 
     @property
-    def message_timestamp(self) -> int:
+    def message_timestamp(self) -> float:
         """Return the message timestamp from the payload."""
-        return self._payload.get("messageTimeStamp", 0)
+        val = self._payload.get("messageTimeStamp", 0)
+        return val / 1000 if val else 0
 
     @property
     def ui_state(self) -> LGHorizonUIState | None:
@@ -992,14 +994,16 @@ class LGHorizonReplayEvent:
         return self._raw_json.get("seasonNumber")
 
     @property
-    def start_time(self) -> Optional[int]:
-        """Return the start time."""
-        return self._raw_json.get("startTime", None)
+    def start_time(self) -> Optional[float]:
+        """Return the start time as Unix timestamp in seconds."""
+        val = self._raw_json.get("startTime")
+        return val / 1000 if val is not None else None
 
     @property
-    def end_time(self) -> Optional[int]:
-        """Return the end time."""
-        return self._raw_json.get("endTime", None)
+    def end_time(self) -> Optional[float]:
+        """Return the end time as Unix timestamp in seconds."""
+        val = self._raw_json.get("endTime")
+        return val / 1000 if val is not None else None
 
     @property
     def title(self) -> str:
@@ -1401,14 +1405,16 @@ class LGHorizonEpgEvent:
         return self._event_json.get("title", "")
 
     @property
-    def start_time(self) -> Optional[int]:
+    def start_time(self) -> Optional[float]:
         """Return the start time as Unix timestamp in seconds."""
-        return self._event_json.get("startTime")
+        val = self._event_json.get("startTime")
+        return val / 1000 if val is not None else None
 
     @property
-    def end_time(self) -> Optional[int]:
+    def end_time(self) -> Optional[float]:
         """Return the end time as Unix timestamp in seconds."""
-        return self._event_json.get("endTime")
+        val = self._event_json.get("endTime")
+        return val / 1000 if val is not None else None
 
     @property
     def minimum_age(self) -> int:
@@ -1552,14 +1558,16 @@ class LGHorizonEventDetail:
         return self._detail_json.get("episodeNumber")
 
     @property
-    def start_time(self) -> Optional[int]:
+    def start_time(self) -> Optional[float]:
         """Return the start time as Unix timestamp in seconds."""
-        return self._detail_json.get("startTime")
+        val = self._detail_json.get("startTime")
+        return val / 1000 if val is not None else None
 
     @property
-    def end_time(self) -> Optional[int]:
+    def end_time(self) -> Optional[float]:
         """Return the end time as Unix timestamp in seconds."""
-        return self._detail_json.get("endTime")
+        val = self._detail_json.get("endTime")
+        return val / 1000 if val is not None else None
 
     @property
     def actors(self) -> List[str]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,8 +102,8 @@ def sample_replay_event_json():
         "episodeName": "Pilot",
         "seasonNumber": 1,
         "episodeNumber": 1,
-        "startTime": 1700000000,
-        "endTime": 1700003600,
+        "startTime": 1700000000000,
+        "endTime": 1700003600000,
     }
 
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -276,7 +276,7 @@ async def test_handle_ui_status_message_calls_process_ui_state(device, processor
 async def test_handle_ui_status_message_sets_timestamp(device):
     msg = _make_ui_status_message(timestamp=9999)
     await device.handle_ui_status_message(msg)
-    assert device.last_ui_message_timestamp == 9999
+    assert device.last_ui_message_timestamp == 9.999
 
 
 @pytest.mark.asyncio

--- a/tests/test_device_state_processor.py
+++ b/tests/test_device_state_processor.py
@@ -328,9 +328,9 @@ class TestProcessLinearState:
 
         await processor.process_ui_state(device_state, self._linear_ui_msg())
 
-        assert device_state.start_time == 1700000000
-        assert device_state.end_time == 1700003600
-        assert device_state.duration == 3600
+        assert device_state.start_time == 1700000000.0
+        assert device_state.end_time == 1700003600.0
+        assert device_state.duration == 3600.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -497,7 +497,7 @@ class TestLGHorizonPlayerState:
 
     def test_last_speed_change_time(self):
         ps = LGHorizonPlayerState({"lastSpeedChangeTime": 1700000000})
-        assert ps.last_speed_change_time == 1700000000
+        assert ps.last_speed_change_time == 1700000.0
 
     def test_relative_position(self):
         ps = LGHorizonPlayerState({"relativePosition": 60000})
@@ -754,7 +754,7 @@ class TestLGHorizonUIStatusMessage:
 
     def test_message_timestamp(self, sample_ui_status_payload):
         msg = LGHorizonUIStatusMessage(sample_ui_status_payload, "test/topic")
-        assert msg.message_timestamp == 1700000000
+        assert msg.message_timestamp == 1700000.0
 
     def test_message_timestamp_default(self):
         msg = LGHorizonUIStatusMessage({}, "test/topic")
@@ -1064,11 +1064,11 @@ class TestLGHorizonReplayEvent:
 
     def test_start_time(self, sample_replay_event_json):
         ev = LGHorizonReplayEvent(sample_replay_event_json)
-        assert ev.start_time == 1700000000
+        assert ev.start_time == 1700000000.0
 
     def test_end_time(self, sample_replay_event_json):
         ev = LGHorizonReplayEvent(sample_replay_event_json)
-        assert ev.end_time == 1700003600
+        assert ev.end_time == 1700003600.0
 
     def test_full_episode_title_with_name(self, sample_replay_event_json):
         ev = LGHorizonReplayEvent(sample_replay_event_json)
@@ -1248,11 +1248,11 @@ class TestLGHorizonEpgEvent:
 
     def test_start_time(self):
         ev = LGHorizonEpgEvent(_EPG_EVENT_JSON, "NL_001")
-        assert ev.start_time == 1000
+        assert ev.start_time == 1.0
 
     def test_end_time(self):
         ev = LGHorizonEpgEvent(_EPG_EVENT_JSON, "NL_001")
-        assert ev.end_time == 2000
+        assert ev.end_time == 2.0
 
     def test_minimum_age(self):
         ev = LGHorizonEpgEvent(_EPG_EVENT_JSON, "NL_001")
@@ -1435,11 +1435,11 @@ class TestLGHorizonEventDetail:
 
     def test_start_time(self):
         d = LGHorizonEventDetail(_EVENT_DETAIL_JSON)
-        assert d.start_time == 1000
+        assert d.start_time == 1.0
 
     def test_end_time(self):
         d = LGHorizonEventDetail(_EVENT_DETAIL_JSON)
-        assert d.end_time == 2000
+        assert d.end_time == 2.0
 
     def test_actors(self):
         d = LGHorizonEventDetail(_EVENT_DETAIL_JSON)


### PR DESCRIPTION
API returns timestamps in milliseconds. Model properties now convert to seconds (/ 1000) so consumers can compare directly with time.time().

Affected: ReplayEvent, EpgEvent, EventDetail, PlayerState, UIStatusMessage. Removed redundant / 1000 in device_state_processor for last_speed_change_time. Updated test fixtures to use realistic millisecond values.