### PR TITLE
Fix: EPG and EventDetail startTime/endTime are already seconds, not ms

### DIFF
--- a/lghorizon/lghorizon_models.py
+++ b/lghorizon/lghorizon_models.py
@@ -1405,14 +1405,12 @@ class LGHorizonEpgEvent:
     @property
     def start_time(self) -> Optional[float]:
         """Return the start time as Unix timestamp in seconds."""
-        val = self._event_json.get("startTime")
-        return val / 1000 if val is not None else None
+        return self._event_json.get("startTime")
 
     @property
     def end_time(self) -> Optional[float]:
         """Return the end time as Unix timestamp in seconds."""
-        val = self._event_json.get("endTime")
-        return val / 1000 if val is not None else None
+        return self._event_json.get("endTime")
 
     @property
     def minimum_age(self) -> int:
@@ -1558,14 +1556,12 @@ class LGHorizonEventDetail:
     @property
     def start_time(self) -> Optional[float]:
         """Return the start time as Unix timestamp in seconds."""
-        val = self._detail_json.get("startTime")
-        return val / 1000 if val is not None else None
+        return self._detail_json.get("startTime")
 
     @property
     def end_time(self) -> Optional[float]:
         """Return the end time as Unix timestamp in seconds."""
-        val = self._detail_json.get("endTime")
-        return val / 1000 if val is not None else None
+        return self._detail_json.get("endTime")
 
     @property
     def actors(self) -> List[str]:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1248,11 +1248,11 @@ class TestLGHorizonEpgEvent:
 
     def test_start_time(self):
         ev = LGHorizonEpgEvent(_EPG_EVENT_JSON, "NL_001")
-        assert ev.start_time == 1.0
+        assert ev.start_time == 1000
 
     def test_end_time(self):
         ev = LGHorizonEpgEvent(_EPG_EVENT_JSON, "NL_001")
-        assert ev.end_time == 2.0
+        assert ev.end_time == 2000
 
     def test_minimum_age(self):
         ev = LGHorizonEpgEvent(_EPG_EVENT_JSON, "NL_001")
@@ -1435,11 +1435,11 @@ class TestLGHorizonEventDetail:
 
     def test_start_time(self):
         d = LGHorizonEventDetail(_EVENT_DETAIL_JSON)
-        assert d.start_time == 1.0
+        assert d.start_time == 1000
 
     def test_end_time(self):
         d = LGHorizonEventDetail(_EVENT_DETAIL_JSON)
-        assert d.end_time == 2.0
+        assert d.end_time == 2000
 
     def test_actors(self):
         d = LGHorizonEventDetail(_EVENT_DETAIL_JSON)


### PR DESCRIPTION
The epgPackager-lite and linearService APIs return timestamps in seconds. Only PlayerState.lastSpeedChangeTime and UIStatusMessage.messageTimeStamp are in milliseconds. Removed incorrect /1000 from EpgEvent and EventDetail.