### PR TITLE
Fix NDVR recording timestamp parsing crashing on numeric epoch values

### DIFF
--- a/lghorizon/lghorizon_device_state_processor.py
+++ b/lghorizon/lghorizon_device_state_processor.py
@@ -324,18 +324,14 @@ class LGHorizonDeviceStateProcessor:
             player_state.last_speed_change_time
         )
         device_state.position = int(player_state.relative_position / 1000)
-        if recording.start_time:
-            device_state.start_time = int(
-                dt.fromisoformat(
-                    recording.start_time.replace("Z", "+00:00")
-                ).timestamp()
-            )
-        if recording.end_time:
-            device_state.end_time = int(
-                dt.fromisoformat(recording.end_time.replace("Z", "+00:00")).timestamp()
-            )
-        if recording.start_time and recording.end_time:
-            device_state.duration = device_state.end_time - device_state.start_time
+        parsed_start = self._parse_timestamp(recording.start_time)
+        parsed_end = self._parse_timestamp(recording.end_time)
+        if parsed_start is not None:
+            device_state.start_time = parsed_start
+        if parsed_end is not None:
+            device_state.end_time = parsed_end
+        if parsed_start is not None and parsed_end is not None:
+            device_state.duration = parsed_end - parsed_start
         if recording.source == LGHorizonRecordingSource.SHOW:
             device_state.show_title = recording.title
         else:
@@ -344,6 +340,17 @@ class LGHorizonDeviceStateProcessor:
         device_state.media_type = LGHorizonMediaType.CHANNEL
 
         device_state.image = await self._get_intent_image_url(recording.id)
+
+    def _parse_timestamp(self, value) -> Optional[int]:
+        """Parse a timestamp that may be numeric epoch seconds or an ISO-8601 string."""
+        if value is None:
+            return None
+        try:
+            if isinstance(value, (int, float)):
+                return int(value)
+            return int(dt.fromisoformat(value.replace("Z", "+00:00")).timestamp())
+        except Exception:
+            return None
 
     async def _get_intent_image_url(self, intent_id: str) -> Optional[str]:
         """Get intent image url."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1937,3 +1937,32 @@ class TestAuthRequest:
         assert fetch_idx < last_request_idx, (
             f"fetch_access_token (idx {fetch_idx}) should come before retry request (idx {last_request_idx})"
         )
+
+
+class TestNdvrTimestampParsing:
+    """Tests for LGHorizonDeviceStateProcessor._parse_timestamp helper."""
+
+    def _make_processor(self):
+        from lghorizon.lghorizon_device_state_processor import LGHorizonDeviceStateProcessor
+        return LGHorizonDeviceStateProcessor(None, {}, None, None)
+
+    def test_numeric_epoch_seconds(self):
+        proc = self._make_processor()
+        assert proc._parse_timestamp(1714060800) == 1714060800
+
+    def test_numeric_float(self):
+        proc = self._make_processor()
+        assert proc._parse_timestamp(1714060800.9) == 1714060800
+
+    def test_iso8601_string(self):
+        proc = self._make_processor()
+        result = proc._parse_timestamp("2024-04-25T20:00:00Z")
+        assert result == 1714075200
+
+    def test_none_returns_none(self):
+        proc = self._make_processor()
+        assert proc._parse_timestamp(None) is None
+
+    def test_invalid_string_returns_none(self):
+        proc = self._make_processor()
+        assert proc._parse_timestamp("not-a-date") is None


### PR DESCRIPTION
The recording detail API returns startTime/endTime as epoch seconds (numbers), but _process_ndvr_state assumed ISO-8601 strings and called .replace() on them, causing an AttributeError. This left duration, show_title, media_type and image unset for recordings.

Add _parse_timestamp helper that handles both numeric epochs and ISO-8601 strings with safe fallback.